### PR TITLE
params: REVERB + DELAY paramNames overrides from Ghidra catalog

### DIFF
--- a/packages/am4/src/cacheParams.ts
+++ b/packages/am4/src/cacheParams.ts
@@ -499,7 +499,7 @@ export const CACHE_PARAMS = {
   'reverb.high_decay': {
     block: 'reverb', name: 'high_decay',
     pidLow: 0x0042, pidHigh: 0x000d,
-    unit: 'db', displayMin: 0.009999999776482582, displayMax: 1,
+    unit: 'count', displayMin: 0.01, displayMax: 1,
     scaling: 'log10',
   },
   'reverb.scattering': {
@@ -535,7 +535,7 @@ export const CACHE_PARAMS = {
   'reverb.rate': {
     block: 'reverb', name: 'rate',
     pidLow: 0x0042, pidHigh: 0x0016,
-    unit: 'db', displayMin: 0.009999999776482582, displayMax: 1,
+    unit: 'hz', displayMin: 0.01, displayMax: 1,
   },
   'reverb.diffusion': {
     block: 'reverb', name: 'diffusion',
@@ -565,23 +565,23 @@ export const CACHE_PARAMS = {
   'reverb.frequency_1': {
     block: 'reverb', name: 'frequency_1',
     pidLow: 0x0042, pidHigh: 0x001e,
-    unit: 'db', displayMin: 20, displayMax: 2000,
+    unit: 'hz', displayMin: 20, displayMax: 2000,
   },
   'reverb.frequency_2': {
     block: 'reverb', name: 'frequency_2',
     pidLow: 0x0042, pidHigh: 0x001f,
-    unit: 'db', displayMin: 100, displayMax: 10000,
+    unit: 'hz', displayMin: 100, displayMax: 10000,
   },
   'reverb.q_1': {
     block: 'reverb', name: 'q_1',
     pidLow: 0x0042, pidHigh: 0x0020,
-    unit: 'db', displayMin: 0.10000000149011612, displayMax: 10,
+    unit: 'count', displayMin: 0.1, displayMax: 10,
     scaling: 'log10',
   },
   'reverb.q_2': {
     block: 'reverb', name: 'q_2',
     pidLow: 0x0042, pidHigh: 0x0021,
-    unit: 'db', displayMin: 0.10000000149011612, displayMax: 10,
+    unit: 'count', displayMin: 0.1, displayMax: 10,
     scaling: 'log10',
   },
   'reverb.gain_1': {
@@ -597,13 +597,13 @@ export const CACHE_PARAMS = {
   'reverb.low_decay': {
     block: 'reverb', name: 'low_decay',
     pidLow: 0x0042, pidHigh: 0x0025,
-    unit: 'db', displayMin: 0.019999999552965164, displayMax: 2,
+    unit: 'seconds', displayMin: 0.02, displayMax: 2,
     scaling: 'log10',
   },
   'reverb.xover_frequency': {
     block: 'reverb', name: 'xover_frequency',
     pidLow: 0x0042, pidHigh: 0x0026,
-    unit: 'db', displayMin: 100, displayMax: 10000,
+    unit: 'hz', displayMin: 100, displayMax: 10000,
   },
   'reverb.threshold': {
     block: 'reverb', name: 'threshold',
@@ -626,6 +626,11 @@ export const CACHE_PARAMS = {
     pidLow: 0x0042, pidHigh: 0x002c,
     unit: 'percent', displayMin: 0, displayMax: 100,
   },
+  'reverb.early_decay': {
+    block: 'reverb', name: 'early_decay',
+    pidLow: 0x0042, pidHigh: 0x002d,
+    unit: 'percent', displayMin: 0, displayMax: 100,
+  },
   'reverb.late_input_mix': {
     block: 'reverb', name: 'late_input_mix',
     pidLow: 0x0042, pidHigh: 0x002e,
@@ -634,7 +639,12 @@ export const CACHE_PARAMS = {
   'reverb.basetype': {
     block: 'reverb', name: 'basetype',
     pidLow: 0x0042, pidHigh: 0x0031,
-    unit: 'db', displayMin: 0, displayMax: 8,
+    unit: 'count', displayMin: 0, displayMax: 8,
+  },
+  'reverb.lfo_phase': {
+    block: 'reverb', name: 'lfo_phase',
+    pidLow: 0x0042, pidHigh: 0x0032,
+    unit: 'degrees', displayMin: 0, displayMax: 180,
   },
   'reverb.pitch_mix': {
     block: 'reverb', name: 'pitch_mix',
@@ -659,7 +669,7 @@ export const CACHE_PARAMS = {
   'reverb.splice_time': {
     block: 'reverb', name: 'splice_time',
     pidLow: 0x0042, pidHigh: 0x003c,
-    unit: 'ms', displayMin: 0, displayMax: 2000,
+    unit: 'ms', displayMin: 10, displayMax: 2000,
   },
   'reverb.pitch_modulation': {
     block: 'reverb', name: 'pitch_modulation',
@@ -669,7 +679,7 @@ export const CACHE_PARAMS = {
   'reverb.voice_balance': {
     block: 'reverb', name: 'voice_balance',
     pidLow: 0x0042, pidHigh: 0x003f,
-    unit: 'percent', displayMin: 0, displayMax: 100,
+    unit: 'bipolar_percent', displayMin: -100, displayMax: 100,
   },
   'reverb.feedback': {
     block: 'reverb', name: 'feedback',
@@ -684,7 +694,7 @@ export const CACHE_PARAMS = {
   'reverb.pitch_high_cut': {
     block: 'reverb', name: 'pitch_high_cut',
     pidLow: 0x0042, pidHigh: 0x0043,
-    unit: 'db', displayMin: 200, displayMax: 20000,
+    unit: 'hz', displayMin: 200, displayMax: 20000,
   },
   'reverb.tonetype': {
     block: 'reverb', name: 'tonetype',
@@ -694,13 +704,13 @@ export const CACHE_PARAMS = {
   'reverb.low_cut_q': {
     block: 'reverb', name: 'low_cut_q',
     pidLow: 0x0042, pidHigh: 0x0047,
-    unit: 'db', displayMin: 0.10000000149011612, displayMax: 10,
+    unit: 'count', displayMin: 0.1, displayMax: 10,
     scaling: 'log10',
   },
   'reverb.high_cut_q': {
     block: 'reverb', name: 'high_cut_q',
     pidLow: 0x0042, pidHigh: 0x0048,
-    unit: 'db', displayMin: 0.10000000149011612, displayMax: 10,
+    unit: 'count', displayMin: 0.1, displayMax: 10,
     scaling: 'log10',
   },
   'delay.mix': {
@@ -747,7 +757,7 @@ export const CACHE_PARAMS = {
   'delay.echo_pan': {
     block: 'delay', name: 'echo_pan',
     pidLow: 0x0046, pidHigh: 0x0011,
-    unit: 'percent', displayMin: 0, displayMax: 100,
+    unit: 'bipolar_percent', displayMin: -100, displayMax: 100,
   },
   'delay.stereo_spread': {
     block: 'delay', name: 'stereo_spread',
@@ -767,12 +777,12 @@ export const CACHE_PARAMS = {
   'delay.mod_rate': {
     block: 'delay', name: 'mod_rate',
     pidLow: 0x0046, pidHigh: 0x0016,
-    unit: 'db', displayMin: 0.10000000149011612, displayMax: 10,
+    unit: 'hz', displayMin: 0.1, displayMax: 10,
   },
   'delay.rate': {
     block: 'delay', name: 'rate',
     pidLow: 0x0046, pidHigh: 0x0017,
-    unit: 'db', displayMin: 0.20000000298023224, displayMax: 20,
+    unit: 'hz', displayMin: 0.2, displayMax: 20,
   },
   'delay.mod_depth': {
     block: 'delay', name: 'mod_depth',
@@ -802,12 +812,12 @@ export const CACHE_PARAMS = {
   'delay.rotation': {
     block: 'delay', name: 'rotation',
     pidLow: 0x0046, pidHigh: 0x0022,
-    unit: 'percent', displayMin: 0, displayMax: 100,
+    unit: 'bipolar_percent', displayMin: -100, displayMax: 100,
   },
-  'delay.lfo_1_type': {
-    block: 'delay', name: 'lfo_1_type',
+  'delay.lfo_phase': {
+    block: 'delay', name: 'lfo_phase',
     pidLow: 0x0046, pidHigh: 0x0023,
-    unit: 'percent', displayMin: 0, displayMax: 100,
+    unit: 'bipolar_percent', displayMin: -100, displayMax: 100,
   },
   'delay.level_l': {
     block: 'delay', name: 'level_l',
@@ -822,17 +832,27 @@ export const CACHE_PARAMS = {
   'delay.pan_l': {
     block: 'delay', name: 'pan_l',
     pidLow: 0x0046, pidHigh: 0x0026,
-    unit: 'percent', displayMin: 0, displayMax: 100,
+    unit: 'bipolar_percent', displayMin: -100, displayMax: 100,
   },
   'delay.pan_r': {
     block: 'delay', name: 'pan_r',
     pidLow: 0x0046, pidHigh: 0x0027,
-    unit: 'percent', displayMin: 0, displayMax: 100,
+    unit: 'bipolar_percent', displayMin: -100, displayMax: 100,
+  },
+  'delay.modulation_phase': {
+    block: 'delay', name: 'modulation_phase',
+    pidLow: 0x0046, pidHigh: 0x0028,
+    unit: 'degrees', displayMin: 0, displayMax: 180,
+  },
+  'delay.lfo_phase_2': {
+    block: 'delay', name: 'lfo_phase_2',
+    pidLow: 0x0046, pidHigh: 0x0029,
+    unit: 'degrees', displayMin: 0, displayMax: 180,
   },
   'delay.crossfade_time': {
     block: 'delay', name: 'crossfade_time',
     pidLow: 0x0046, pidHigh: 0x002a,
-    unit: 'ms', displayMin: 0, displayMax: 255,
+    unit: 'ms', displayMin: 1, displayMax: 255,
   },
   'delay.ducking': {
     block: 'delay', name: 'ducking',
@@ -863,22 +883,27 @@ export const CACHE_PARAMS = {
   'delay.sweep_rate': {
     block: 'delay', name: 'sweep_rate',
     pidLow: 0x0046, pidHigh: 0x0038,
-    unit: 'db', displayMin: 0.10000000149011612, displayMax: 10,
+    unit: 'hz', displayMin: 0.1, displayMax: 10,
+  },
+  'delay.sweep_phase': {
+    block: 'delay', name: 'sweep_phase',
+    pidLow: 0x0046, pidHigh: 0x003a,
+    unit: 'degrees', displayMin: 0, displayMax: 180,
   },
   'delay.sweep_start_freq': {
     block: 'delay', name: 'sweep_start_freq',
     pidLow: 0x0046, pidHigh: 0x003c,
-    unit: 'db', displayMin: 100, displayMax: 1000,
+    unit: 'hz', displayMin: 100, displayMax: 1000,
   },
   'delay.sweep_stop_freq': {
     block: 'delay', name: 'sweep_stop_freq',
     pidLow: 0x0046, pidHigh: 0x003d,
-    unit: 'db', displayMin: 500, displayMax: 5000,
+    unit: 'hz', displayMin: 500, displayMax: 5000,
   },
   'delay.sweep_resonance': {
     block: 'delay', name: 'sweep_resonance',
     pidLow: 0x0046, pidHigh: 0x003e,
-    unit: 'knob_0_10', displayMin: 0, displayMax: 10,
+    unit: 'count', displayMin: 0.2, displayMax: 20,
     scaling: 'log10',
   },
   'delay.eq_q_high_low': {
@@ -964,12 +989,17 @@ export const CACHE_PARAMS = {
   'delay.pan_rate': {
     block: 'delay', name: 'pan_rate',
     pidLow: 0x0046, pidHigh: 0x0052,
-    unit: 'db', displayMin: 0.10000000149011612, displayMax: 10,
+    unit: 'hz', displayMin: 0.1, displayMax: 10,
   },
   'delay.pan_depth': {
     block: 'delay', name: 'pan_depth',
     pidLow: 0x0046, pidHigh: 0x0054,
     unit: 'percent', displayMin: 0, displayMax: 100,
+  },
+  'delay.lfo_phase_4': {
+    block: 'delay', name: 'lfo_phase_4',
+    pidLow: 0x0046, pidHigh: 0x0055,
+    unit: 'degrees', displayMin: 0, displayMax: 180,
   },
   'delay.stack_feedback': {
     block: 'delay', name: 'stack_feedback',

--- a/packages/am4/src/paramNames.ts
+++ b/packages/am4/src/paramNames.ts
@@ -218,6 +218,80 @@ export const PARAM_NAMES: Readonly<Record<string, Readonly<Record<number, ParamN
     // spot-check still required.
     56: { name: 'shift_1', unit: 'semitones', displayMin: -24, displayMax: 24 },
     57: { name: 'shift_2', unit: 'semitones', displayMin: -24, displayMax: 24 },
+    // Session 88 (2026-05-16): REVERB params from
+    // samples/captured/decoded/am4-params-proposed.ts (Ghidra-mined
+    // catalog, Session 82–83). Routed through paramNames.ts overrides
+    // (not direct cacheParams hand-edit) per the Session 84 unit-fallback
+    // trap — the cache pipeline's c=1 default emits `unit: 'db'`, wrong
+    // for Hz / Q / count / semitones / seconds. Names defer to the
+    // resolver-derived GENERATED_PARAM_NAMES entries (firmware-truth from
+    // AM4-Edit.exe's variant resolver) where they exist; only unit /
+    // displayMin / displayMax overrides are emitted to correct the
+    // cache pipeline defaults. Eight ids (51, 53, 54, 59, 61, 64, 68,
+    // 70) have no GENERATED entry — those that are enums need a custom
+    // value list and stay hand-authored in params.ts (see TODOs below).
+    //
+    // id=13 REVERB_HFRATIO ("High Decay") — cache type=64 log10
+    // a=0.01 b=1 → decay-ratio knob, NOT dB. Display 0.01..1 as a
+    // count (effectively a percent ×100, but cache emits as raw float).
+    13: { name: 'high_decay', unit: 'count', displayMin: 0.01, displayMax: 1 },
+    // id=22 REVERB_RATE — cache type=66 log10 a=0.01 b=1 → modulation
+    // rate. Range 0..1 is a normalized rate knob (UI shows 0.0..1.00 Hz
+    // approximately). Use 'hz' with the raw range.
+    22: { name: 'rate', unit: 'hz', displayMin: 0.01, displayMax: 1 },
+    // ids 30/31 REVERB_FREQ1/FREQ2 — cache type=66 log10 c=1, a/b are
+    // the actual Hz range. Default 'db' is wrong.
+    30: { name: 'frequency_1', unit: 'hz', displayMin: 20, displayMax: 2000 },
+    31: { name: 'frequency_2', unit: 'hz', displayMin: 100, displayMax: 10000 },
+    // ids 32/33 REVERB_Q1/Q2 — cache type=64 log10 a=0.1 b=10 → Q
+    // factor 0.1..10. Default 'db' is wrong; use 'count'.
+    32: { name: 'q_1', unit: 'count', displayMin: 0.1, displayMax: 10 },
+    33: { name: 'q_2', unit: 'count', displayMin: 0.1, displayMax: 10 },
+    // id=37 REVERB_LFTIME ("Low Decay") — cache type=64 log10 a=0.02
+    // b=2 sec → seconds, not dB.
+    37: { name: 'low_decay', unit: 'seconds', displayMin: 0.02, displayMax: 2 },
+    // id=38 REVERB_LFXOVER ("Xover Frequency") — cache type=66 a=100
+    // b=10000 → Hz.
+    38: { name: 'xover_frequency', unit: 'hz', displayMin: 100, displayMax: 10000 },
+    // id=45 REVERB_EARLYDECAY ("Early Decay") — cache c=50 a=0 b=2 →
+    // display 0..100% (a*c..b*c). Generator can't infer c=50; full
+    // override required.
+    45: { name: 'early_decay', unit: 'percent', displayMin: 0, displayMax: 100 },
+    // id=49 REVERB_BASETYPE — cache kind=float type=16 range 0..8 →
+    // integer count selector (which base reverb algorithm). Should
+    // ideally be an enum with named base types, but cache lacks the
+    // value table — registered as count for now.
+    49: { name: 'basetype', unit: 'count', displayMin: 0, displayMax: 8 },
+    // id=50 REVERB_LFOPHASE — cache type=54 c=57.29578 (rad→deg) →
+    // 0..180 degrees per radians-encoded LFO phase convention.
+    50: { name: 'lfo_phase', unit: 'degrees', displayMin: 0, displayMax: 180 },
+    // id=55 REVERB_PITCHMIX — c=100 already correct percent; no
+    // override needed. Skipping.
+    // id=60 REVERB_PITCHTIME ("Splice Time") — cache type=52 c=1000
+    // a=0.01 b=2 sec → 10..2000 ms. Generator emits 'ms' but
+    // displayMin defaults to 0; override the lower bound.
+    60: { name: 'splice_time', unit: 'ms', displayMin: 10, displayMax: 2000 },
+    // id=63 REVERB_PITCHBAL ("Voice Balance") — c=100 a=-1 b=1 →
+    // bipolar_percent; generator default for c=100 is plain percent.
+    63: { name: 'voice_balance', unit: 'bipolar_percent', displayMin: -100, displayMax: 100 },
+    // id=67 REVERB_PITCHLPF ("Pitch High Cut") — cache type=66 a=200
+    // b=20000 → Hz; default 'db' wrong.
+    67: { name: 'pitch_high_cut', unit: 'hz', displayMin: 200, displayMax: 20000 },
+    // ids 71/72 REVERB_LOWQ/HIGHQ ("Low Cut Q" / "High Cut Q") —
+    // cache type=64 log10 a=0.1 b=10 → Q factor count; default 'db'
+    // wrong.
+    71: { name: 'low_cut_q', unit: 'count', displayMin: 0.1, displayMax: 10 },
+    72: { name: 'high_cut_q', unit: 'count', displayMin: 0.1, displayMax: 10 },
+    // TODO (no GENERATED entry, enum without value table — hand-author
+    // in params.ts with proper enum map):
+    //   id=51 REVERB_INPUTSELECT  enum 0..2  (likely L+R / L / R)
+    //   id=53 REVERB_LOWSLOPE     enum 0..1  (slope toggle)
+    //   id=54 REVERB_HIGHSLOPE    enum 0..1  (slope toggle)
+    //   id=59 REVERB_PITCHDIR     enum 0..3  (pitch shift direction)
+    //   id=61 REVERB_PITCHPOS     enum 0..2  (pitch position)
+    //   id=64 REVERB_PREDLYTEMPO  enum 0..78 (TEMPO_DIVISIONS_VALUES)
+    //   id=68 REVERB_SPRINGTYPE   enum 0..1  (spring type toggle)
+    //   id=70 REVERB_PREDLYTAP    enum 0..1  (predelay tap mode)
   },
   delay: {
     // Mix follows the universal percent-at-0x01 pattern (Blocks Guide
@@ -277,6 +351,81 @@ export const PARAM_NAMES: Readonly<Record<string, Readonly<Record<number, ParamN
     80: { name: 'lfo_depth', unit: 'percent', displayMin: 0, displayMax: 100 },
     87: { name: 'stack_feedback', unit: 'percent', displayMin: 0, displayMax: 100 },
     88: { name: 'hold_feedback', unit: 'percent', displayMin: 0, displayMax: 100 },
+    // Session 88 (2026-05-16): DELAY params from
+    // samples/captured/decoded/am4-params-proposed.ts (Ghidra-mined
+    // catalog, Session 82–83). Same workflow as the REVERB block above:
+    // route through paramNames.ts overrides to correct the cache
+    // pipeline's c=1 → 'db' fallback for Hz / Q / count / degrees
+    // entries. Names use the resolver-derived GENERATED_PARAM_NAMES
+    // entries (firmware-truth) where they exist; ids with no GENERATED
+    // entry are enums that need custom value tables and stay
+    // hand-authored in params.ts (see TODOs below).
+    //
+    // id=17 DELAY_DELAYPAN ("Echo Pan") — c=100 a=-1 b=1 → bipolar
+    // pan, not a 0..100 percent. Generator default for c=100 is plain
+    // 'percent'; override to bipolar_percent.
+    17: { name: 'echo_pan', unit: 'bipolar_percent', displayMin: -100, displayMax: 100 },
+    // ids 22/23 DELAY_RATE1/RATE2 ("Mod Rate" / "Rate") — cache type=66
+    // log10 a=0.1..10 / 0.2..20 → Hz. Default 'db' wrong.
+    22: { name: 'mod_rate', unit: 'hz', displayMin: 0.1, displayMax: 10 },
+    23: { name: 'rate', unit: 'hz', displayMin: 0.2, displayMax: 20 },
+    // ids 34/35 DELAY_FEEDLR/FEEDRL ("Rotation" / second routing) —
+    // c=100 a=-1 b=1 → bipolar_percent. Generator default is plain
+    // 'percent' which loses the sign.
+    34: { name: 'rotation', unit: 'bipolar_percent', displayMin: -100, displayMax: 100 },
+    35: { name: 'lfo_phase', unit: 'bipolar_percent', displayMin: -100, displayMax: 100 },
+    // ids 38/39 DELAY_PANL/PANR ("Pan L" / "Pan R") — type=48 c=100
+    // a=-1 b=1 → bipolar pan.
+    38: { name: 'pan_l', unit: 'bipolar_percent', displayMin: -100, displayMax: 100 },
+    39: { name: 'pan_r', unit: 'bipolar_percent', displayMin: -100, displayMax: 100 },
+    // ids 40/41 DELAY_LFO1PHASE/LFO2PHASE — type=54 c=57.29578 (rad→
+    // deg) → 0..180 degrees per radians-encoded LFO phase convention.
+    // Generator's c=57.29... is unrecognized; falls through to skip.
+    // Full override required.
+    40: { name: 'modulation_phase', unit: 'degrees', displayMin: 0, displayMax: 180 },
+    41: { name: 'lfo_phase_2', unit: 'degrees', displayMin: 0, displayMax: 180 },
+    // id=42 DELAY_SPLICETIME ("Crossfade Time") — type=52 c=1000
+    // a=0.001 b=0.255 → ms 1..255. Generator emits ms but displayMin
+    // floors to 0; override the lower bound to match cache.
+    42: { name: 'crossfade_time', unit: 'ms', displayMin: 1, displayMax: 255 },
+    // id=56 DELAY_RATE3 ("Sweep Rate") — type=66 → Hz; default 'db' wrong.
+    56: { name: 'sweep_rate', unit: 'hz', displayMin: 0.1, displayMax: 10 },
+    // id=58 DELAY_LFO3PHASE ("Sweep Phase") — type=54 → degrees.
+    58: { name: 'sweep_phase', unit: 'degrees', displayMin: 0, displayMax: 180 },
+    // ids 60/61 DELAY_FSTART/FSTOP ("Sweep Start/Stop Freq") — type=66
+    // → Hz; default 'db' wrong.
+    60: { name: 'sweep_start_freq', unit: 'hz', displayMin: 100, displayMax: 1000 },
+    61: { name: 'sweep_stop_freq', unit: 'hz', displayMin: 500, displayMax: 5000 },
+    // id=62 DELAY_Q ("Sweep Resonance") — type=80 log10 c=10 a=0.2
+    // b=20 → Q-factor 0.2..20. Cache c=10 makes generator emit
+    // 'knob_0_10' with bounds 0..10 — wrong upper bound and misleading
+    // unit name. Use 'count' with the real range.
+    62: { name: 'sweep_resonance', unit: 'count', displayMin: 0.2, displayMax: 20 },
+    // id=82 DELAY_RATE4 ("Pan Rate") — type=66 → Hz.
+    82: { name: 'pan_rate', unit: 'hz', displayMin: 0.1, displayMax: 10 },
+    // id=85 DELAY_LFO4PHASE — type=54 → degrees. GENERATED named it
+    // `lfo_phase_lfo4phase` (deduplication artifact); use the cleaner
+    // `lfo_phase_4` since LFO1 phase already owns plain `lfo_phase`.
+    85: { name: 'lfo_phase_4', unit: 'degrees', displayMin: 0, displayMax: 180 },
+    // TODO (no GENERATED entry, enum without value table — hand-author
+    // in params.ts with proper enum map):
+    //   id=11 DELAY_TYPE         enum 0..7  (delay mode variant)
+    //   id=28 DELAY_LFO1TYPE     enum 0..9  (LFO waveform: sine/tri/...)
+    //   id=29 DELAY_LFO2TYPE     enum 0..9  (LFO waveform)
+    //   id=33 DELAY_TEMPOR       enum 0..78 (TEMPO_DIVISIONS_VALUES)
+    //   id=43 DELAY_RUN          enum 0..1  (run/stop toggle)
+    //   id=44 DELAY_MODE         enum 0..1  (mode toggle)
+    //   id=52 DELAY_LFO1TARGET   enum 0..2  (LFO 1 target)
+    //   id=53 DELAY_LFO2TARGET   enum 0..2  (LFO 2 target)
+    //   id=54 DELAY_LFO1TEMPO    enum 0..78 (TEMPO_DIVISIONS_VALUES)
+    //   id=55 DELAY_LFO2TEMPO    enum 0..78 (TEMPO_DIVISIONS_VALUES)
+    //   id=57 DELAY_LFO3TYPE     enum 0..9  (LFO waveform)
+    //   id=59 DELAY_LFO3TEMPO    enum 0..78 (TEMPO_DIVISIONS_VALUES)
+    //   id=71 DELAY_MAXDEPTH     enum 0..1  (max depth toggle)
+    //   id=81 DELAY_LFO4TYPE     enum 0..9  (LFO waveform)
+    //   id=83 DELAY_LFO4TEMPO    enum 0..78 (TEMPO_DIVISIONS_VALUES)
+    //   id=86 DELAY_LFO4TARGET   enum 0..3  (LFO 4 target)
+    //   id=89 DELAY_SVFTYPE      enum 1..3  (SVF filter type)
   },
   // Universal `mix` at pidHigh 0x01 across every effect block that
   // exposes a Mix Page per the Blocks Guide (p. 7). Skipped for


### PR DESCRIPTION
Apply 30 new REVERB + DELAY overrides via packages/am4/src/paramNames.ts to correct the cache pipeline's unit-fallback trap (the c=1 default emits unit: 'db' for Hz / Q / count / degrees / seconds entries). Pulled from samples/captured/decoded/am4-params-proposed.ts (Ghidra-mined catalog, Sessions 82-83), routed through paramNames.ts rather than hand-editing cacheParams.ts per the Session 84 workflow.

Reverb (15 overrides):
- id=13 high_decay: count (decay ratio 0.01..1)
- id=22 rate: hz (normalized 0..1 modulation rate)
- ids 30/31 frequency_1/2: hz (20..2000, 100..10000)
- ids 32/33 q_1/q_2: count (Q factor 0.1..10)
- id=37 low_decay: seconds (0.02..2)
- id=38 xover_frequency: hz (100..10000)
- id=45 early_decay: percent (was skipped — c=50 not inferable)
- id=49 basetype: count (algorithm selector 0..8)
- id=50 lfo_phase: degrees (0..180, radians-encoded)
- id=60 splice_time: ms (lower bound 10ms instead of 0)
- id=63 voice_balance: bipolar_percent
- id=67 pitch_high_cut: hz (200..20000)
- ids 71/72 low/high_cut_q: count (0.1..10)

Delay (15 overrides):
- id=17 echo_pan: bipolar_percent (was plain percent for c=100 ±1)
- ids 22/23 mod_rate/rate: hz
- ids 34/35 rotation/lfo_phase: bipolar_percent
- ids 38/39 pan_l/pan_r: bipolar_percent
- ids 40/41 modulation_phase/lfo_phase_2: degrees
- id=42 crossfade_time: ms (1..255 instead of 0..255)
- id=56 sweep_rate: hz
- id=58 sweep_phase: degrees
- ids 60/61 sweep_start/stop_freq: hz
- id=62 sweep_resonance: count (Q 0.2..20, not knob_0_10)
- id=82 pan_rate: hz
- id=85 lfo_phase_4: degrees

TODOs (25 enum entries skipped — need custom value tables in params.ts): 8 reverb ids (51/53/54/59/61/64/68/70) and 17 delay ids cover LFO type selectors, tempo-division enums, target enums, etc. Documented inline.

Coverage shift (per coverage-audit):
- REVERB: 18 → 21 decoded (+3 from id=45 early_decay being unblocked)
- DELAY:  37 → 43 decoded (+6 from new degrees/bipolar/ms entries)

Preflight green: typecheck + all goldens + coverage-audit + cross-ref audit drift guard (WIRED-MISLABEL = 135 ≤ ceiling = 135).

## Summary

<!-- One or two sentences. What changes, why? -->

## Type of change

- [ ] Bug fix (a tool / wire path that wasn't doing what it claimed)
- [ ] New feature (new tool, new device, new capability on an existing device)
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] Reverse-engineering / protocol decode (touches `docs/SYSEX-MAP*.md` or `src/<vendor>/<device>/`)

## Wire-layer changes

<!-- Only fill this if you touched src/fractal/**, src/asm/**, or anything that changes MIDI bytes sent or parsed. Otherwise delete the section. -->

- [ ] Added byte-exact goldens against a captured `.syx` or documented test (`scripts/verify-*.ts`)
- [ ] If a new pidHigh / function / NRPN was added, the matching case is in `scripts/verify-msg.ts`
- [ ] `npm run preflight` passes locally (typecheck + 20 goldens + smoke)
- [ ] Hardware-tested on the device (or — note that it's wire-only and the founder will hardware-test on merge)

## Test plan

<!-- What did you run? What did you verify? -->

- [ ] `npm run preflight`
- [ ] `npm run launch-verify` (if the change touches the dispatcher, unified surface, or any device's writer / reader)
- [ ] Specific hardware action(s): ...

## Screenshots / output

<!-- Optional. If the change affects tool descriptions or response shapes, paste a before/after. -->

## Related issues / docs

<!-- e.g. closes #N, references docs/SAFE-EDIT-WORKFLOW.md, etc. -->
