### PR TITLE
fm3: decode the live grid read (sub=0x2E)

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "verify-preset-portability": "tsx scripts/mcp-test-preset-portability.ts",
     "verify-fm9-rosters": "tsx scripts/verify-fm9-rosters.ts",
     "verify-fm9-ranges": "tsx scripts/verify-fm9-ranges.ts",
+    "verify-fm3-grid-2e": "tsx scripts/verify-fm3-grid-2e.ts",
     "verify-fm9-end-to-end": "tsx scripts/verify-fm9-end-to-end.ts",
     "test:fractal-midi": "npm test --workspace=fractal-midi",
     "test": "npm run test:fractal-midi && npm run test:codec && npm run test:cross-device && npm run test:fractal-gen2 && npm run test:fractal-gen3 && npm run test:hydra && npm run test:server",
@@ -194,7 +195,7 @@
     "deadcode:fix": "knip --fix",
     "catalog:check": "npm run catalog:check --workspace=fractal-midi",
     "catalog:export": "npm run catalog:export --workspace=fractal-midi",
-    "preflight": "npm run build && npm run typecheck && npm test && npm run catalog:check && npm run verify-no-internal-refs && npm run cookbook-verify && npm run tools:inventory-check && npm run verify-tool-annotations && npm run verify-preset-portability && npm run verify-fm9-rosters && npm run verify-fm9-ranges && npm run verify-fm9-end-to-end",
+    "preflight": "npm run build && npm run typecheck && npm test && npm run catalog:check && npm run verify-no-internal-refs && npm run cookbook-verify && npm run tools:inventory-check && npm run verify-tool-annotations && npm run verify-preset-portability && npm run verify-fm9-rosters && npm run verify-fm9-ranges && npm run verify-fm3-grid-2e && npm run verify-fm9-end-to-end",
     "release-gate": "npm run preflight && npm run test:release-extras && npm run launch-verify && npm run agent-sweep && npm run live-regression"
   },
   "devDependencies": {

--- a/packages/fractal-midi/src/gen3/axe-fx-iii/gridLayout.ts
+++ b/packages/fractal-midi/src/gen3/axe-fx-iii/gridLayout.ts
@@ -58,6 +58,24 @@ const FIELD_CABLE_IN = 16; // bits 16-23: incoming-cable bitmask
 
 const BLOCK_TYPE_SHUNT = 0x08;
 
+// ── FM3 (model 0x11) sub=0x2E layout ──
+// The FM3 grid response uses a DIFFERENT per-cell layout from the FM9/III (not just
+// a region-offset shift). Decoded byte-exact from two FM3 device captures (a linear
+// 12-col chain + a multi-row preset with cross-row cables): column-major 12x4, one
+// 32-bit big-endian record per cell, empty cell = all zero.
+//   bits 31-20 (12) = effectId (real block) | shuntIndex (shunt)
+//   bits 19-16 (4)  = unused
+//   bits 15-8  (8)  = type: 0x00 real block, 0x40 shunt
+//   bits  7-0  (8)  = incoming-cable mask, source row r of the prior column -> bit (4+r)
+// Region starts at mido bit 2568 (= wire byte 366, intra-byte bit 6).
+const FM3_REGION_OFFSET = 366;
+const FM3_BASE_BIT = 6;
+const FM3_COL_STRIDE = 128; // 4 rows * 32
+const FM3_ROW_STRIDE = 32;
+const FM3_BLOCK_TYPE_SHUNT = 0x40;
+const FM3_GRID_COLS = 12;
+const FM3_GRID_ROWS = 4;
+
 /** Grid rows for a model byte: 4 for FM3, 6 for III/FM9. */
 function gridRowsFor(modelByte: number): number {
   return modelByte === MODEL_FM3 ? 4 : 6;
@@ -125,6 +143,7 @@ export function parseGen3GridLayout(
   frame: readonly number[],
   modelByte: number = AXE_FX_III_MODEL_ID,
 ): Gen3GridLayoutCell[] {
+  if (modelByte === MODEL_FM3) return parseFm3GridLayout(frame);
   // mido strips the F0 status byte; the offset 361 is into that stream.
   const mido = frame.length >= 2 && frame[0] === SYSEX_START ? frame.slice(1) : frame;
   const region = mido.slice(GRID_REGION_OFFSET);
@@ -150,6 +169,44 @@ export function parseGen3GridLayout(
         isShunt,
         shuntIndex: isShunt ? idField : undefined,
         cableInputMask: readBitsMsb(region, base + FIELD_CABLE_IN, 8),
+      });
+    }
+  }
+  return cells;
+}
+
+/**
+ * FM3 (model 0x11) sub=0x2E decode. The FM3 uses a 32-bit-per-cell, column-major
+ * 12x4 layout that differs from the FM9/III bit-field grid (see the FM3_* constants
+ * above). `cableInputMask` is normalized so bit `r` set = fed from row `r` of the
+ * previous column. Byte-exact against two FM3 device captures.
+ */
+function parseFm3GridLayout(frame: readonly number[]): Gen3GridLayoutCell[] {
+  const mido = frame.length >= 2 && frame[0] === SYSEX_START ? frame.slice(1) : frame;
+  const region = mido.slice(FM3_REGION_OFFSET);
+  const lastBit = FM3_BASE_BIT + (FM3_GRID_COLS - 1) * FM3_COL_STRIDE + (FM3_GRID_ROWS - 1) * FM3_ROW_STRIDE + 32;
+  if (region.length * 7 < lastBit) {
+    throw new Error(
+      `parseGen3GridLayout(FM3): frame too short for grid region (have ${region.length} region bytes, need ${Math.ceil(lastBit / 7)})`,
+    );
+  }
+  const cells: Gen3GridLayoutCell[] = [];
+  for (let col = 0; col < FM3_GRID_COLS; col++) {
+    for (let row = 0; row < FM3_GRID_ROWS; row++) {
+      const base = FM3_BASE_BIT + col * FM3_COL_STRIDE + row * FM3_ROW_STRIDE;
+      const idField = readBitsMsb(region, base, 12); // bits 31-20 of the 32-bit BE cell
+      const blockType = readBitsMsb(region, base + 16, 8); // bits 15-8
+      const cableByte = readBitsMsb(region, base + 24, 8); // bits 7-0
+      const isShunt = blockType === FM3_BLOCK_TYPE_SHUNT;
+      if (idField === 0 && !isShunt) continue; // empty cell
+      cells.push({
+        row,
+        col,
+        effectId: isShunt ? undefined : idField,
+        isShunt,
+        shuntIndex: isShunt ? idField : undefined,
+        // FM3 packs source rows in bits 4-7; normalize so bit r = source row r.
+        cableInputMask: (cableByte >> 4) & 0x0f,
       });
     }
   }

--- a/scripts/verify-fm3-grid-2e.ts
+++ b/scripts/verify-fm3-grid-2e.ts
@@ -1,0 +1,75 @@
+/**
+ * Gate: the FM3 (model 0x11) sub=0x2E live-grid decode must reproduce a known
+ * device capture exactly. Frame below is an empty-target sub=0x2E response from a
+ * real FM3 (fw 12.0) for the factory-style preset "Harmonic Voltage" — a multi-row
+ * layout with parallel rows and cross-row cables. The expected cells are the
+ * ground truth from the same preset's whole-preset dump decode.
+ *
+ * A regression in parseGen3GridLayout's FM3 branch (offset/stride/field/cable-mask)
+ * fails here instead of silently shipping a wrong grid.
+ */
+import { parseGen3GridLayout } from '../packages/fractal-midi/src/gen3/axe-fx-iii/gridLayout.js';
+
+const MODEL_FM3 = 0x11;
+
+// Raw sub=0x2E response (F0..F7), FM3 fw 12.0, preset "Harmonic Voltage".
+const FRAME = (
+  'f0 00 01 74 11 01 2e 00 00 00 00 00 00 00 00 00 00 00 00 70 03 53 00 20 00 00 00 00 00 00 00 00 00 00 03 6c 76 58 10 29 06 0b 49 5a 6f 37 1a 2c 32 02 59 5e 6c 3a 18 2c 76 29 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 00 49 37 1d 0e 26 79 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 00 04 6b 05 52 6e 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 00 29 5e 2d 67 23 20 40 32 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 00 02 4d 5e 6c 37 48 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 00 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 00 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 00 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 00 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 04 02 01 00 40 20 10 08 00 00 00 00 00 00 00 00 00 00 01 14 00 00 00 00 00 00 00 00 00 00 00 00 07 20 00 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 40 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 09 10 00 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7c 00 02 00 10 20 00 10 00 00 00 00 00 00 00 00 00 00 39 40 01 40 00 00 00 00 00 13 40 00 20 00 00 00 00 00 00 00 00 00 00 32 00 01 00 00 00 00 00 00 00 00 00 00 02 18 00 09 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 42 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 0b 60 00 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 07 50 00 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 54 00 02 00 00 00 00 00 00 59 f7'
+)
+  .trim()
+  .split(/\s+/)
+  .map((x) => parseInt(x, 16));
+
+// Ground truth (col, row, eid, isShunt, fromRows) from the whole-preset dump decode.
+const EXPECTED = [
+  [0, 2, 37, false, []],
+  [1, 1, 58, false, [2]],
+  [2, 2, 0, true, [1]],
+  [3, 2, 146, false, [2]],
+  [4, 2, 62, false, [2]],
+  [4, 3, 130, false, [2]],
+  [5, 2, 115, false, [2, 3]],
+  [6, 0, 78, false, [2]],
+  [6, 3, 50, false, [2]],
+  [7, 2, 70, false, [0, 3]],
+  [8, 2, 66, false, [2]],
+  [9, 2, 47, false, [2]],
+  [10, 2, 122, false, [2]],
+  [11, 2, 42, false, [2]],
+] as const;
+
+const cells = parseGen3GridLayout(FRAME, MODEL_FM3);
+const got = new Map(cells.map((c) => [`${c.col},${c.row}`, c]));
+const fromRowsOf = (mask: number) => {
+  const rs: number[] = [];
+  for (let r = 0; r < 4; r++) if (mask & (1 << r)) rs.push(r);
+  return rs;
+};
+
+let failed = 0;
+function check(label: string, cond: boolean, detail: string) {
+  if (cond) console.log(`  ok    ${label}`);
+  else {
+    console.error(`  FAIL  ${label} (${detail})`);
+    failed++;
+  }
+}
+
+check(`cell count = ${EXPECTED.length}`, cells.length === EXPECTED.length, `got ${cells.length}`);
+for (const [col, row, eid, isShunt, fromRows] of EXPECTED) {
+  const c = got.get(`${col},${row}`);
+  const id = c ? (c.isShunt ? c.shuntIndex : c.effectId) : undefined;
+  const fr = c ? fromRowsOf(c.cableInputMask) : [];
+  const ok = !!c && c.isShunt === isShunt && id === eid && JSON.stringify(fr) === JSON.stringify(fromRows);
+  check(
+    `c${col} r${row}: ${isShunt ? `shunt#${eid}` : `eid ${eid}`} fromRows=[${fromRows}]`,
+    ok,
+    c ? `got ${c.isShunt ? `shunt#${c.shuntIndex}` : `eid ${c.effectId}`} fromRows=[${fr}]` : 'missing',
+  );
+}
+
+if (failed > 0) {
+  console.error(`\nverify-fm3-grid-2e: ${failed} check(s) FAILED`);
+  process.exit(1);
+}
+console.log('\nverify-fm3-grid-2e: all checks passed (FM3 sub=0x2E decode byte-exact vs device capture)');


### PR DESCRIPTION
## Summary

Adds FM3 (model `0x11`) support to `parseGen3GridLayout` — the live `sub=0x2E` grid read. FM3's response uses a **different per-cell layout** from the FM9/III (a 32-bit-per-cell, column-major 12×4 grid, not the FM9 bit-field layout), so this adds a dedicated FM3 decode branch rather than a region-offset tweak. Closes the open FM3 item flagged in `gridLayout.ts` ("FM3 … region offset may differ … community-beta until a capture confirms").

## Type of change

- [x] Reverse-engineering / protocol decode (touches the `fractal-midi` codec)

## Wire-layer changes

- [x] Added a byte-exact golden (`scripts/verify-fm3-grid-2e.ts`) from a real FM3 `sub=0x2E` capture, wired into `preflight`.
- [x] Hardware-sourced: decoded from **two** FM3 device captures (a linear chain + a multi-row preset with cross-row cables), cross-validated against the whole-preset dump decoder as ground truth.
- [ ] full `npm run preflight` run locally — ran the FM3 grid verify + a package typecheck on my side; CI runs the rest.

## Test plan

- `npx tsx scripts/verify-fm3-grid-2e.ts` → **14/14 cells byte-exact** (positions, effectIds, shunts, and cable routing).

## The decode (for SYSEX-MAP / cookbook)

FM3 `sub=0x2E` cell = 32-bit big-endian, column-major 12×4, base mido-bit 2568 (wire byte 366 + bit 6), col stride 128, row stride 32, empty cell = all zero:
- bits 31–20: `effectId` (block) | `shuntIndex` (shunt)
- bits 15–8: type — `0x00` real block, `0x40` shunt
- bits 7–0: incoming-cable mask — source row `r` of the prior column → bit `4+r`

Differs from FM9/III (8-bit `id<<1`, type `0x08`, 6-row 192-bit col stride).

## Notes

- `cableInputMask` is normalized so bit `r` = source row `r` (FM3 packs them in bits 4–7).
- Companion FM3 work: device-synced cache + `FM3_RANGES` (#7), and FM3 hardware confirmations incl. `set_block`/routing/save (#8, #9).

Suggested label: `community-beta`.
